### PR TITLE
Remove unused Dockerfile for Jira test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-empty docker file for testing


### PR DESCRIPTION
This pull request removes an obsolete and unused Dockerfile associated with Jira test configurations. The file is no longer required and its removal helps in keeping the repository clean and maintainable.

No functional or feature changes are included in this PR